### PR TITLE
DSL Style for Byte Array Creation

### DIFF
--- a/Sources/BitWiser/DSL/ByteArrayBuilder.swift
+++ b/Sources/BitWiser/DSL/ByteArrayBuilder.swift
@@ -7,8 +7,10 @@
 
 import Foundation
 
+
+/// `ByteArrayBuilder` is a `@resultBuilder` to create sequence of `Byte` in a DSL style
 @resultBuilder
-public struct ByteArrayBuilder {
+public enum ByteArrayBuilder {
     
     public static func buildBlock(_ components: [Byte]...) -> [Byte] {
         components.flatMap { $0 }

--- a/Sources/BitWiser/DSL/ByteArrayBuilder.swift
+++ b/Sources/BitWiser/DSL/ByteArrayBuilder.swift
@@ -1,0 +1,42 @@
+//
+//  ByteArrayBuilder.swift
+//  
+//
+//  Created by Andrea Finollo on 30/01/22.
+//
+
+import Foundation
+
+@resultBuilder
+public struct ByteArrayBuilder {
+    
+    public static func buildBlock(_ components: [Byte]...) -> [Byte] {
+        components.flatMap { $0 }
+    }
+    
+    public static func buildExpression(_ expression: [Byte]) -> [Byte] {
+        expression
+    }
+    
+    public static func buildExpression(_ expression: Byte) -> [Byte] {
+        [expression]
+    }
+    
+    public static func buildOptional(_ component: [Byte]?) -> [Byte] {
+        component ?? []
+    }
+    
+    public static func buildEither(first component: [Byte]) -> [Byte] {
+        component
+    }
+    
+    public static func buildEither(second component: [Byte]) -> [Byte] {
+        component
+    }
+    
+    public static func buildArray(_ components: [[Byte]]) -> [Byte] {
+        return components.flatMap { $0 }
+    }
+    
+    
+}

--- a/Sources/BitWiser/DSL/DataConvertibleBuilder.swift
+++ b/Sources/BitWiser/DSL/DataConvertibleBuilder.swift
@@ -1,0 +1,69 @@
+//
+//  DataConvertibleBuilder.swift
+//  
+//
+//  Created by Andrea Finollo on 04/02/22.
+//
+
+import Foundation
+
+/// `DataConvertibleBuilder` is a `@resultBuilder` to create  `Data` in a DSL style
+@resultBuilder
+public enum DataConvertibleBuilder {
+    
+    public static func buildBlock(_ components: DataConvertible...) -> Data {
+        return components.reduce(Data()) { partialResult, value in
+            var mutBuffer = partialResult
+            mutBuffer.append(value.data)
+            return mutBuffer
+        }
+    }
+    
+    public static func buildExpression(_ expression: [DataConvertible]) -> Data {
+        return expression.reduce(Data()) { partialResult, value in
+            var mutBuffer = partialResult
+            mutBuffer.append(value.data)
+            return mutBuffer
+        }
+    }
+    
+    public static func buildExpression(_ expression: DataConvertible) -> Data {
+        expression.data
+    }
+    
+    public static func buildOptional(_ component: [DataConvertible]?) -> Data {
+        let data = component?.reduce(Data()) { partialResult, value in
+            var mutBuffer = partialResult
+            mutBuffer.append(value.data)
+            return mutBuffer
+        }
+        return data ?? Data()
+    }
+    
+    public static func buildEither(first component: [DataConvertible]) -> Data {
+        return component.reduce(Data()) { partialResult, value in
+            var mutBuffer = partialResult
+            mutBuffer.append(value.data)
+            return mutBuffer
+        }
+    }
+    
+    public static func buildEither(second component: [DataConvertible]) -> Data {
+        return component.reduce(Data()) { partialResult, value in
+            var mutBuffer = partialResult
+            mutBuffer.append(value.data)
+            return mutBuffer
+        }
+    }
+    
+    public static func buildArray(_ components: [[DataConvertible]]) -> Data {
+        return components
+            .flatMap { $0 }
+            .reduce(Data()) { partialResult, value in
+                var mutBuffer = partialResult
+                mutBuffer.append(value.data)
+                return mutBuffer
+            }
+    }
+    
+}

--- a/Sources/BitWiser/DSL/DataConvertibleBuilder.swift
+++ b/Sources/BitWiser/DSL/DataConvertibleBuilder.swift
@@ -31,34 +31,20 @@ public enum DataConvertibleBuilder {
         expression.data
     }
     
-    public static func buildOptional(_ component: [DataConvertible]?) -> Data {
-        let data = component?.reduce(Data()) { partialResult, value in
-            var mutBuffer = partialResult
-            mutBuffer.append(value.data)
-            return mutBuffer
-        }
-        return data ?? Data()
+    public static func buildOptional(_ component: DataConvertible?) -> Data {
+        return component?.data ?? Data()
     }
     
-    public static func buildEither(first component: [DataConvertible]) -> Data {
-        return component.reduce(Data()) { partialResult, value in
-            var mutBuffer = partialResult
-            mutBuffer.append(value.data)
-            return mutBuffer
-        }
+    public static func buildEither(first component: DataConvertible) -> Data {
+        return component.data
     }
     
-    public static func buildEither(second component: [DataConvertible]) -> Data {
-        return component.reduce(Data()) { partialResult, value in
-            var mutBuffer = partialResult
-            mutBuffer.append(value.data)
-            return mutBuffer
-        }
+    public static func buildEither(second component: DataConvertible) -> Data {
+        return component.data
     }
     
-    public static func buildArray(_ components: [[DataConvertible]]) -> Data {
+    public static func buildArray(_ components: [DataConvertible]) -> Data {
         return components
-            .flatMap { $0 }
             .reduce(Data()) { partialResult, value in
                 var mutBuffer = partialResult
                 mutBuffer.append(value.data)

--- a/Sources/BitWiser/DataRepresentable/DataRepresentable.swift
+++ b/Sources/BitWiser/DataRepresentable/DataRepresentable.swift
@@ -1,0 +1,18 @@
+//
+//  DataRepresentable.swift
+//  
+//
+//  Created by Andrea Finollo on 04/02/22.
+//
+
+import Foundation
+
+public protocol ExpressibleByData {
+    init?(data: Data)
+}
+
+public protocol DataConvertible {
+    var data: Data { get }
+}
+
+public typealias DataRepresentable = ExpressibleByData & DataConvertible

--- a/Sources/BitWiser/Extension/Extension+Data.swift
+++ b/Sources/BitWiser/Extension/Extension+Data.swift
@@ -18,6 +18,17 @@ extension Data: ByteRepresentable {
     }
 }
 
+extension Data : DataConvertible {
+    
+    public init?(data: Data) {
+        self.init(data)
+    }
+    
+    public var data: Data {
+        return self
+    }
+}
+
 public extension Data {
     
     /// Option about how to encode the hex string representation

--- a/Sources/BitWiser/Extension/Extension+Data.swift
+++ b/Sources/BitWiser/Extension/Extension+Data.swift
@@ -57,18 +57,21 @@ public extension Data {
 }
 
 public extension Data {
-    /// Initialize a `Data` with a `@ByteArrayBuilder`.
+
+    /// Initialize a `Data` with a `@DataConvertibleBuilder`.
     ///
     ///     Data {
     ///         [Byte(0x00)]
     ///         Byte(0x01)
     ///         0x02
-    ///         [UInt8(0x03)]
+    ///         "\u{03}"
+    ///         CustomObject()
     ///     }
-    ///     
-    /// - parameter builder: A DSL closure with `Byte`s.
-    /// - Important: Always start from the LSB
-    init(@ByteArrayBuilder _ builder: () -> [Byte]) {
-        self.init(bytes: builder())
+    ///
+    /// - parameter representables: A DSL closure with `DataRepresentable`s. Object passed in the closure must conform to `DataRepresentable` protocol.
+    /// - Note: Objects passed in the closure can have different `Data` lenght.
+    /// - Important: Always start from the LSB.
+    init(@DataConvertibleBuilder _ representables: () -> Data) {
+        self.init(representables())
     }
 }

--- a/Sources/BitWiser/Extension/Extension+Data.swift
+++ b/Sources/BitWiser/Extension/Extension+Data.swift
@@ -44,3 +44,9 @@ public extension Data {
         }.joined(separator: padding)
     }
 }
+
+public extension Data {
+    init(@ByteArrayBuilder _ builder: () -> [Byte]) {
+        self.init(bytes: builder())
+    }
+}

--- a/Sources/BitWiser/Extension/Extension+Data.swift
+++ b/Sources/BitWiser/Extension/Extension+Data.swift
@@ -46,6 +46,17 @@ public extension Data {
 }
 
 public extension Data {
+    /// Initialize a `Data` with a `@ByteArrayBuilder`.
+    ///
+    ///     Data {
+    ///         [Byte(0x00)]
+    ///         Byte(0x01)
+    ///         0x02
+    ///         [UInt8(0x03)]
+    ///     }
+    ///     
+    /// - parameter builder: A DSL closure with `Byte`s.
+    /// - Important: Always start from the LSB
     init(@ByteArrayBuilder _ builder: () -> [Byte]) {
         self.init(bytes: builder())
     }

--- a/Sources/BitWiser/Extension/Extension+Numeric.swift
+++ b/Sources/BitWiser/Extension/Extension+Numeric.swift
@@ -103,3 +103,20 @@ extension Array where Element == Byte {
         return or
     }
 }
+
+public extension Array where Element == Byte {
+    /// Initialize a `[Byte]`Array  with a `@ByteArrayBuilder`.
+    ///
+    ///     Array<Byte> {
+    ///         [Byte(0x00)]
+    ///         Byte(0x01)
+    ///         0x02
+    ///         [UInt8(0x03)]
+    ///     }
+    ///
+    /// - parameter builder: A DSL closure with `Byte`s.
+    /// - Important: Always start from the LSB
+    init(@ByteArrayBuilder _ builder: () -> [Byte]) {
+        self.init(builder())
+    }
+}

--- a/Sources/BitWiser/Extension/Extension+Numeric.swift
+++ b/Sources/BitWiser/Extension/Extension+Numeric.swift
@@ -7,6 +7,34 @@
 
 import Foundation
 
+extension DataConvertible where Self: ExpressibleByIntegerLiteral{
+    public init?(data: Data) {
+        var value: Self = 0
+        guard data.count == MemoryLayout.size(ofValue: value) else { return nil }
+        _ = withUnsafeMutableBytes(of: &value, { data.copyBytes(to: $0)} )
+        self = value
+    }
+
+    public var data: Data {
+        return withUnsafeBytes(of: self) { Data($0) }
+    }
+}
+
+extension Int8: DataConvertible { }
+extension Int16: DataConvertible { }
+extension Int32: DataConvertible { }
+extension Int64: DataConvertible { }
+extension Int: DataConvertible { }
+
+extension Float: DataConvertible { }
+extension Double: DataConvertible { }
+
+extension UInt8: DataConvertible { }
+extension UInt16: DataConvertible { }
+extension UInt32: DataConvertible { }
+extension UInt64: DataConvertible { }
+extension UInt: DataConvertible { }
+
 // MARK: - Signed Numeric
 
 extension Int16: ByteConvertible {

--- a/Sources/BitWiser/Extension/Extension+String.swift
+++ b/Sources/BitWiser/Extension/Extension+String.swift
@@ -7,6 +7,18 @@
 
 import Foundation
 
+extension String: DataConvertible {
+    
+    public init?(data: Data) {
+        self.init(data: data, encoding: .utf8)
+    }
+    
+    public var data: Data {
+        // Note: a conversion to UTF-8 cannot fail.
+        return Data(self.utf8)
+    }
+}
+
 public extension String {
     /// Given a hex string it returns a Data
     /// - Returns: a `Data` value

--- a/Tests/BitWiserTests/ByteTests.swift
+++ b/Tests/BitWiserTests/ByteTests.swift
@@ -16,7 +16,7 @@ class ByteTests: XCTestCase {
         var hexDescription = value.hexDescription
         XCTAssertTrue(binDescription == "00000000")
         XCTAssertTrue(hexDescription == "00")
-
+        
         value = 0b11111111
         binDescription = value.binaryDescription
         hexDescription = value.hexDescription

--- a/Tests/BitWiserTests/DSLTests.swift
+++ b/Tests/BitWiserTests/DSLTests.swift
@@ -134,4 +134,36 @@ class DSLTests: XCTestCase {
         XCTAssertEqual(dslByteArray, bytes)
         XCTAssertEqual(dslData, dataFromValue)
     }
+    
+    @DataConvertibleBuilder func buildDataFromVaridicData() -> Data {
+        UInt8(0)
+        UInt8(1)
+        UInt8(2)
+        UInt8(3)
+        UInt8(4)
+    }
+    
+    @DataConvertibleBuilder func buildDataFromVaridicDataArrayOfData() -> Data {
+        [UInt8(0)]
+        [UInt8(1)]
+        [UInt8(2)]
+        [UInt8(3)]
+        [UInt8(4)]
+    }
+    
+    @DataConvertibleBuilder func buildDataFromVaridicMixedData() -> Data {
+        [UInt8(0)]
+        UInt8(1)
+        Int8(2)
+        "\u{03}"
+        Int16(1284)
+    }
+    
+
+}
+
+struct CustomData: DataConvertible {
+    var data: Data {
+        Data()
+    }    
 }

--- a/Tests/BitWiserTests/DSLTests.swift
+++ b/Tests/BitWiserTests/DSLTests.swift
@@ -146,9 +146,10 @@ class DSLTests: XCTestCase {
         let bytes = value.bytes
         let dataFromValue = Data(bytes: bytes)
         
+        // Must use UInt8 to define the lenght
         let dslData = Data {
-            0b1010_1010
-            0b1100_1100
+            Byte(0b1010_1010)
+            Byte(0b1100_1100)
         }
         
         let dslByteArray = Array<Byte> {

--- a/Tests/BitWiserTests/DSLTests.swift
+++ b/Tests/BitWiserTests/DSLTests.swift
@@ -1,0 +1,41 @@
+//
+//  DSLTests.swift
+//  
+//
+//  Created by Andrea Finollo on 30/01/22.
+//
+
+import XCTest
+@testable import BitWiser
+
+class DSLTests: XCTestCase {
+    
+    @ByteArrayBuilder func buildArrayOfBytesFromVaridicBytes() -> [Byte] {
+        Byte(0x00)
+        Byte(0x01)
+        Byte(0x02)
+        Byte(0x03)
+        UInt8(0x4)
+    }
+
+    @ByteArrayBuilder func buildArrayOfBytesFromVaridicByteArrayOfBytes() -> [Byte] {
+        [Byte(0x00)]
+        [Byte(0x01)]
+        [Byte(0x02)]
+        [Byte(0x03)]
+        [UInt8(0x4)]
+    }
+    
+    @ByteArrayBuilder func buildArrayOfBytesFromVaridicMixedByteArrayOfBytes() -> [Byte] {
+        [Byte(0x00)]
+        [Byte(0x01)]
+        Byte(0x02)
+        0x03
+        [UInt8(0x4)]
+        [UInt8](repeating: 0xFF, count: 8)
+    }
+    
+    func testByteArrayCreationFromVaridicArrayOfBytes() throws {
+       
+    }
+}

--- a/Tests/BitWiserTests/DSLTests.swift
+++ b/Tests/BitWiserTests/DSLTests.swift
@@ -146,7 +146,7 @@ class DSLTests: XCTestCase {
         let bytes = value.bytes
         let dataFromValue = Data(bytes: bytes)
         
-        // Must use UInt8 to define the lenght
+        // Must use UInt8 to define the length
         let dslData = Data {
             Byte(0b1010_1010)
             Byte(0b1100_1100)

--- a/Tests/BitWiserTests/DSLTests.swift
+++ b/Tests/BitWiserTests/DSLTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import BitWiser
 
 class DSLTests: XCTestCase {
-    
+        
     @ByteArrayBuilder func buildArrayOfBytesFromVaridicBytes() -> [Byte] {
         Byte(0x00)
         Byte(0x01)
@@ -28,52 +28,86 @@ class DSLTests: XCTestCase {
     
     @ByteArrayBuilder func buildArrayOfBytesFromVaridicMixedByteArrayOfBytes() -> [Byte] {
         [Byte(0x00)]
-        [Byte(0x01)]
-        Byte(0x02)
-        0x03
-        [UInt8(0x04)]
-        [UInt8](repeating: 0x05, count: 1)
+        Byte(0x01)
+        0x02
+        [UInt8(0x03)]
+        [UInt8](repeating: 0x04, count: 1)
     }
     
     var clause = true
     
     @ByteArrayBuilder func buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause() -> [Byte] {
         [Byte(0x00)]
-        [Byte(0x01)]
-        Byte(0x02)
-        0x03
-        [UInt8(0x04)]
+        Byte(0x01)
+        0x02
+        [UInt8(0x03)]
         if clause {
-            [UInt8](repeating: 0x05, count: 1)
+            [UInt8](repeating: 0x04, count: 1)
         }
     }
     
     @ByteArrayBuilder func buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfElseClause() -> [Byte] {
         [Byte(0x00)]
-        [Byte(0x01)]
-        Byte(0x02)
-        0x03
-        [UInt8(0x04)]
+        Byte(0x01)
+        0x02
+        [UInt8(0x03)]
         if clause {
-            [UInt8](repeating: 0x05, count: 1)
+            [UInt8](repeating: 0x04, count: 1)
         } else {
+            0x04
             0x05
-            0x06
         }
     }
     
     @ByteArrayBuilder func buildArrayOfBytesFromVaridicMixedByteArrayOfBytesLoop() -> [Byte] {
         [Byte(0x00)]
-        [Byte(0x01)]
-        Byte(0x02)
-        0x03
-        [UInt8(0x04)]
-        for value in [0x05, 0x06] {
+        Byte(0x01)
+        0x02
+        [UInt8(0x03)]
+        for value in [0x04, 0x05] {
             Byte(value)
         }
     }
     
-    func testByteArrayCreationFromVaridicArrayOfBytes() throws {
-       
+    func testArrayOfBytesFromVaridicBytes() throws {
+        let value = buildArrayOfBytesFromVaridicBytes()
+        value.enumerated().forEach { (index, value) in
+            XCTAssertTrue(index == value)
+        }
+    }
+    
+    func testArrayOfBytesFromVaridicByteArrayOfBytes() throws {
+        let value = buildArrayOfBytesFromVaridicByteArrayOfBytes()
+        value.enumerated().forEach { (index, value) in
+            XCTAssertTrue(index == value)
+        }
+    }
+    
+    func testArrayOfBytesFromVaridicMixedByteArrayOfBytes() throws {
+        let value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytes()
+        value.enumerated().forEach { (index, value) in
+            XCTAssertTrue(index == value)
+        }
+    }
+    
+    func testArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause() throws {
+        let value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause()
+        value.enumerated().forEach { (index, value) in
+            XCTAssertTrue(index == value)
+        }
+    }
+    
+    func testArrayOfBytesFromVaridicMixedByteArrayOfBytesIfElseClause() throws {
+        let value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfElseClause()
+        value.enumerated().forEach { (index, value) in
+            XCTAssertTrue(index == value)
+        }
+    }
+    
+    func testArrayOfBytesFromVaridicMixedByteArrayOfBytesLoop() throws {
+        let value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesLoop()
+        value.enumerated().forEach { (index, value) in
+            XCTAssertTrue(index == value)
+        }
     }
 }

--- a/Tests/BitWiserTests/DSLTests.swift
+++ b/Tests/BitWiserTests/DSLTests.swift
@@ -15,7 +15,7 @@ class DSLTests: XCTestCase {
         Byte(0x01)
         Byte(0x02)
         Byte(0x03)
-        UInt8(0x4)
+        UInt8(0x04)
     }
 
     @ByteArrayBuilder func buildArrayOfBytesFromVaridicByteArrayOfBytes() -> [Byte] {
@@ -23,7 +23,7 @@ class DSLTests: XCTestCase {
         [Byte(0x01)]
         [Byte(0x02)]
         [Byte(0x03)]
-        [UInt8(0x4)]
+        [UInt8(0x04)]
     }
     
     @ByteArrayBuilder func buildArrayOfBytesFromVaridicMixedByteArrayOfBytes() -> [Byte] {
@@ -31,8 +31,46 @@ class DSLTests: XCTestCase {
         [Byte(0x01)]
         Byte(0x02)
         0x03
-        [UInt8(0x4)]
-        [UInt8](repeating: 0xFF, count: 8)
+        [UInt8(0x04)]
+        [UInt8](repeating: 0x05, count: 1)
+    }
+    
+    var clause = true
+    
+    @ByteArrayBuilder func buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause() -> [Byte] {
+        [Byte(0x00)]
+        [Byte(0x01)]
+        Byte(0x02)
+        0x03
+        [UInt8(0x04)]
+        if clause {
+            [UInt8](repeating: 0x05, count: 1)
+        }
+    }
+    
+    @ByteArrayBuilder func buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfElseClause() -> [Byte] {
+        [Byte(0x00)]
+        [Byte(0x01)]
+        Byte(0x02)
+        0x03
+        [UInt8(0x04)]
+        if clause {
+            [UInt8](repeating: 0x05, count: 1)
+        } else {
+            0x05
+            0x06
+        }
+    }
+    
+    @ByteArrayBuilder func buildArrayOfBytesFromVaridicMixedByteArrayOfBytesLoop() -> [Byte] {
+        [Byte(0x00)]
+        [Byte(0x01)]
+        Byte(0x02)
+        0x03
+        [UInt8(0x04)]
+        for value in [0x05, 0x06] {
+            Byte(value)
+        }
     }
     
     func testByteArrayCreationFromVaridicArrayOfBytes() throws {

--- a/Tests/BitWiserTests/DSLTests.swift
+++ b/Tests/BitWiserTests/DSLTests.swift
@@ -9,6 +9,13 @@ import XCTest
 @testable import BitWiser
 
 class DSLTests: XCTestCase {
+    
+    struct CustomData: DataConvertible {
+        var data: Data {
+            withUnsafeBytes(of: UInt8(6)) { Data($0) }
+        }
+    }
+
         
     @ByteArrayBuilder func buildArrayOfBytesFromVaridicBytes() -> [Byte] {
         Byte(0x00)
@@ -34,14 +41,14 @@ class DSLTests: XCTestCase {
         [UInt8](repeating: 0x04, count: 1)
     }
     
-    var clause = true
+    var byteArrayClause = true
     
     @ByteArrayBuilder func buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause() -> [Byte] {
         [Byte(0x00)]
         Byte(0x01)
         0x02
         [UInt8(0x03)]
-        if clause {
+        if byteArrayClause {
             [UInt8](repeating: 0x04, count: 1)
         }
     }
@@ -51,7 +58,7 @@ class DSLTests: XCTestCase {
         Byte(0x01)
         0x02
         [UInt8(0x03)]
-        if clause {
+        if byteArrayClause {
             [UInt8](repeating: 0x04, count: 1)
         } else {
             0x04
@@ -94,7 +101,15 @@ class DSLTests: XCTestCase {
     }
     
     func testArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause() throws {
-        let value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause()
+        byteArrayClause = true
+        var value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause()
+        value.enumerated().forEach { (index, value) in
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
+        }
+        
+        byteArrayClause = false
+        value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause()
         value.enumerated().forEach { (index, value) in
             let uIndex = UInt8(index)
             XCTAssertEqual(uIndex, value)
@@ -102,11 +117,20 @@ class DSLTests: XCTestCase {
     }
     
     func testArrayOfBytesFromVaridicMixedByteArrayOfBytesIfElseClause() throws {
-        let value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfElseClause()
+        byteArrayClause = true
+        var value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfElseClause()
         value.enumerated().forEach { (index, value) in
             let uIndex = UInt8(index)
             XCTAssertEqual(uIndex, value)
         }
+        
+        byteArrayClause = false
+        value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfElseClause()
+        value.enumerated().forEach { (index, value) in
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
+        }
+
     }
     
     func testArrayOfBytesFromVaridicMixedByteArrayOfBytesLoop() throws {
@@ -135,6 +159,8 @@ class DSLTests: XCTestCase {
         XCTAssertEqual(dslData, dataFromValue)
     }
     
+    var dataClause = true
+    
     @DataConvertibleBuilder func buildDataFromVaridicData() -> Data {
         UInt8(0)
         UInt8(1)
@@ -157,13 +183,113 @@ class DSLTests: XCTestCase {
         Int8(2)
         "\u{03}"
         Int16(1284)
+        CustomData()
     }
     
+    @DataConvertibleBuilder func buildDataFromVaridicMixedDataIfClause() -> Data {
+        [UInt8(0)]
+        UInt8(1)
+        Int8(2)
+        "\u{03}"
+        Int16(1284)
+        if dataClause {
+            CustomData()
+        }
+    }
+    
+    @DataConvertibleBuilder func buildDataFromVaridicMixedDataIfElseClause() -> Data {
+        [UInt8(0)]
+        UInt8(1)
+        Int8(2)
+        "\u{03}"
+        Int16(1284)
+        if dataClause {
+            CustomData()
+        } else {
+            UInt8(6)
+            UInt8(7)
+        }
+    }
+    
+    @DataConvertibleBuilder func buildDataFromVaridicMixedDataLoop() -> Data {
+        [UInt8(0)]
+        UInt8(1)
+        Int8(2)
+        "\u{03}"
+        Int16(1284)
+        for value in [UInt8(6), UInt8(7)] {
+            value
+        }
+    }
+    
+    func testDataFromVaridicData() throws {
+        let value = buildDataFromVaridicData()
+        value.enumerated().forEach { (index, value) in
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
+        }
+    }
+    
+    func testDataFromVaridicDataArrayOfData() throws {
+        let value = buildDataFromVaridicDataArrayOfData()
+        value.enumerated().forEach { (index, value) in
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
+        }
+    }
+
+    func testDataFromVaridicMixedData() throws {
+        let value = buildDataFromVaridicMixedData()
+        value.enumerated().forEach { (index, value) in
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
+        }
+    }
+
+    func testDataFromVaridicMixedDataIfClause() throws {
+        dataClause = true
+
+        var value = buildDataFromVaridicMixedDataIfClause()
+        value.enumerated().forEach { (index, value) in
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
+        }
+        
+        dataClause = false
+        
+        value = buildDataFromVaridicMixedDataIfClause()
+        value.enumerated().forEach { (index, value) in
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
+        }
+    }
+
+    func testDataFromVaridicMixedDataIfElseClause() throws {
+        dataClause = true
+
+        var value = buildDataFromVaridicMixedDataIfElseClause()
+        value.enumerated().forEach { (index, value) in
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
+        }
+        
+        dataClause = false
+        
+        value = buildDataFromVaridicMixedDataIfElseClause()
+        value.enumerated().forEach { (index, value) in
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
+        }
+
+    }
+
+    func testDataFromVaridicMixedDataLoop() throws {
+        let value = buildDataFromVaridicMixedDataLoop()
+        value.enumerated().forEach { (index, value) in
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
+        }
+    }
 
 }
 
-struct CustomData: DataConvertible {
-    var data: Data {
-        Data()
-    }    
-}

--- a/Tests/BitWiserTests/DSLTests.swift
+++ b/Tests/BitWiserTests/DSLTests.swift
@@ -72,42 +72,66 @@ class DSLTests: XCTestCase {
     func testArrayOfBytesFromVaridicBytes() throws {
         let value = buildArrayOfBytesFromVaridicBytes()
         value.enumerated().forEach { (index, value) in
-            XCTAssertTrue(index == value)
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
         }
     }
     
     func testArrayOfBytesFromVaridicByteArrayOfBytes() throws {
         let value = buildArrayOfBytesFromVaridicByteArrayOfBytes()
         value.enumerated().forEach { (index, value) in
-            XCTAssertTrue(index == value)
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
         }
     }
     
     func testArrayOfBytesFromVaridicMixedByteArrayOfBytes() throws {
         let value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytes()
         value.enumerated().forEach { (index, value) in
-            XCTAssertTrue(index == value)
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
         }
     }
     
     func testArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause() throws {
         let value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfClause()
         value.enumerated().forEach { (index, value) in
-            XCTAssertTrue(index == value)
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
         }
     }
     
     func testArrayOfBytesFromVaridicMixedByteArrayOfBytesIfElseClause() throws {
         let value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesIfElseClause()
         value.enumerated().forEach { (index, value) in
-            XCTAssertTrue(index == value)
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
         }
     }
     
     func testArrayOfBytesFromVaridicMixedByteArrayOfBytesLoop() throws {
         let value = buildArrayOfBytesFromVaridicMixedByteArrayOfBytesLoop()
         value.enumerated().forEach { (index, value) in
-            XCTAssertTrue(index == value)
+            let uIndex = UInt8(index)
+            XCTAssertEqual(uIndex, value)
         }
+    }
+    
+    func testDataConversion() throws {
+        let value = UInt16(0b1100_1100_1010_1010)
+        let bytes = value.bytes
+        let dataFromValue = Data(bytes: bytes)
+        
+        let dslData = Data {
+            0b1010_1010
+            0b1100_1100
+        }
+        
+        let dslByteArray = Array<Byte> {
+            0b1010_1010
+            0b1100_1100
+        }
+        XCTAssertEqual(dslByteArray, bytes)
+        XCTAssertEqual(dslData, dataFromValue)
     }
 }


### PR DESCRIPTION
Thanks to the `ByteArrayBuilder` now byte arrays and `Data` can be created using a specific DSL.
 It also supports `if`, `if` `else` and `for` loops, see Unit Test for more detail
As an example this is valid:
```
Data {
        [Byte(0x00)]
        Byte(0x01)
        0x02
        [UInt8(0x03)]
        if clause {
            [UInt8](repeating: 0x04, count: 1)
        }
}
```
also this: 
```
Array<Byte> {
        [Byte(0x00)]
        Byte(0x01)
        0x02
        [UInt8(0x03)]
        if clause {
            [UInt8](repeating: 0x04, count: 1)
        }
}
```